### PR TITLE
Remove unnecessary threading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.7.10-1.0.8.0"
+version = "1.7.10-1.0.8.1"
 group= "makeo.gadomancy"
 archivesBaseName = "gadomancy"
 

--- a/src/main/java/makeo/gadomancy/client/effect/EffectHandler.java
+++ b/src/main/java/makeo/gadomancy/client/effect/EffectHandler.java
@@ -9,8 +9,12 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 
+import java.util.AbstractList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -30,7 +34,7 @@ public class EffectHandler {
     public static List<FXVortex> fxVortexes = new LinkedList<FXVortex>();
 
     //Object that the EffectHandler locks on.
-    public static final Object lockEffects = new Object();
+    private static final Object lockEffects = new Object();
 
     public static EffectHandler getInstance() {
         return EffectHandler.instance;
@@ -53,75 +57,31 @@ public class EffectHandler {
     }
 
     public void registerVortex(final FXVortex vortex) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                //System.out.println("register");
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.fxVortexes.add(vortex);
-                    vortex.registered = true;
-                }
-            }
-        }).start();
+        EffectHandler.fxVortexes.add(vortex);
+        vortex.registered = true;
     }
 
     public void unregisterVortex(final FXVortex vortex) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                //System.out.println("unregister");
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.fxVortexes.remove(vortex);
-                    vortex.registered = false;
-                }
-            }
-        }).start();
+        EffectHandler.fxVortexes.remove(vortex);
+        vortex.registered = false;
     }
 
     public void registerFlow(final FXFlow flow) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.fxFlows.add(flow);
-                }
-            }
-        }).start();
+        EffectHandler.fxFlows.add(flow);
     }
 
     public void unregisterFlow(final FXFlow flow) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.fxFlows.remove(flow);
-                }
-            }
-        }).start();
+        EffectHandler.fxFlows.remove(flow);
     }
 
     public void registerOrbital(final Orbital orbital) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.orbitals.add(orbital);
-                    orbital.registered = true;
-                }
-            }
-        }).start();
+        EffectHandler.orbitals.add(orbital);
+        orbital.registered = true;
     }
 
     public void unregisterOrbital(final Orbital orbital) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.orbitals.remove(orbital);
-                    orbital.registered = false;
-                }
-            }
-        }).start();
+        EffectHandler.orbitals.remove(orbital);
+        orbital.registered = false;
     }
 
     public void tick() {
@@ -131,16 +91,9 @@ public class EffectHandler {
     }
 
     public void clear() {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (EffectHandler.lockEffects) {
-                    EffectHandler.orbitals.clear();
-                    EffectHandler.fxFlows.clear();
-                    EffectHandler.fxVortexes.clear();
-                }
-            }
-        }).start();
+        EffectHandler.orbitals.clear();
+        EffectHandler.fxFlows.clear();
+        EffectHandler.fxVortexes.clear();
     }
 
     public static class NonReentrantReentrantLock extends ReentrantLock {
@@ -161,5 +114,4 @@ public class EffectHandler {
         }
 
     }
-
 }

--- a/src/main/java/makeo/gadomancy/client/effect/fx/FXFlow.java
+++ b/src/main/java/makeo/gadomancy/client/effect/fx/FXFlow.java
@@ -261,13 +261,11 @@ public class FXFlow {
     }
 
     public static void tickFlows(List<FXFlow> fxFlows) {
-        synchronized (EffectHandler.lockEffects) {
-            for(FXFlow flow : fxFlows) {
-                if((System.currentTimeMillis() - flow.lastUpdateCall) > 1000L) {
-                    EffectHandler.getInstance().unregisterFlow(flow);
-                }
-                flow.tick();
+        for(FXFlow flow : fxFlows) {
+            if((System.currentTimeMillis() - flow.lastUpdateCall) > 1000L) {
+                EffectHandler.getInstance().unregisterFlow(flow);
             }
+            flow.tick();
         }
     }
 

--- a/src/main/java/makeo/gadomancy/client/effect/fx/FXVortex.java
+++ b/src/main/java/makeo/gadomancy/client/effect/fx/FXVortex.java
@@ -115,22 +115,18 @@ public class FXVortex {
     }
 
     public static void sheduleRender(List<FXVortex> vortexes, Tessellator tessellator, float partialTicks) {
-        synchronized (EffectHandler.lockEffects) {
-            for (FXVortex vortex : vortexes) {
-                GL11.glPushMatrix();
-                vortex.render(tessellator, partialTicks);
-                GL11.glPopMatrix();
-            }
+        for (FXVortex vortex : vortexes) {
+            GL11.glPushMatrix();
+            vortex.render(tessellator, partialTicks);
+            GL11.glPopMatrix();
         }
     }
 
     public static void tickVortexes(List<FXVortex> vortexes) {
-        synchronized (EffectHandler.lockEffects) {
-            for(FXVortex vortex : vortexes) {
-                if((System.currentTimeMillis() - vortex.lastUpdateCall) > 100L) {
-                    //System.out.println("tickTimeout");
-                    EffectHandler.getInstance().unregisterVortex(vortex);
-                }
+        for(FXVortex vortex : vortexes) {
+            if((System.currentTimeMillis() - vortex.lastUpdateCall) > 100L) {
+                //System.out.println("tickTimeout");
+                EffectHandler.getInstance().unregisterVortex(vortex);
             }
         }
     }


### PR DESCRIPTION
The overall FPS impact of threading and synchronization is not very significant, but to spin up two new threads per FX created create significant stutter when some gadomancy device enters or leaves the camera.
