### PR TITLE
Missing Hardness fix

### DIFF
--- a/src/main/java/makeo/gadomancy/common/blocks/BlockKnowledgeBook.java
+++ b/src/main/java/makeo/gadomancy/common/blocks/BlockKnowledgeBook.java
@@ -32,6 +32,7 @@ public class BlockKnowledgeBook extends BlockContainer implements IBlockTranspar
 
     public BlockKnowledgeBook() {
         super(Material.circuits);
+        setHardness(0.4F);
         this.setBlockBounds(0.0625F, 0.125F, 0.0625F, 0.9375F, 0.5F, 0.9375F);
         this.setCreativeTab(RegisteredItems.creativeTab);
     }


### PR DESCRIPTION
Notices this when playing with the mod out of pack and it turns out the book is lacking a proper hardness value, meaning just punching if for a split second will cause it to break; not ideal when research is in progress

using another block for reference added a hardness value set to 0.4F   unsure of what values represent how hard something is to mine without a base reference so I set it to 0.4F for what I hope is close to wood

PLEASE CORRECT THE HARDNESS VALUE SET IF ITS NOT IN LINE. thanks ^w^