### PR TITLE
Switch from hacking EnumHelper private apis to a java 9+ compatible reflection/unsafe approach

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1674943145
+//version: 1674988119
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -66,7 +66,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.0.16'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.0.18'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -212,6 +212,25 @@ if (accessTransformersFile) {
     }
     tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(targetFile)
     tasks.srgifyBinpatchedJar.accessTransformerFiles.from(targetFile)
+} else {
+    boolean atsFound = false
+    for (File at : sourceSets.getByName("main").resources.files) {
+        if (at.name.toLowerCase().endsWith("_at.cfg")) {
+            atsFound = true
+            tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(at)
+            tasks.srgifyBinpatchedJar.accessTransformerFiles.from(at)
+        }
+    }
+    for (File at : sourceSets.getByName("api").resources.files) {
+        if (at.name.toLowerCase().endsWith("_at.cfg")) {
+            atsFound = true
+            tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(at)
+            tasks.srgifyBinpatchedJar.accessTransformerFiles.from(at)
+        }
+    }
+    if (atsFound) {
+        logger.warn("Found and added access transformers in the resources folder, please configure gradle.properties to explicitly mention them by name")
+    }
 }
 
 if (usesMixins.toBoolean()) {
@@ -352,6 +371,16 @@ configurations.configureEach {
                 // https://www.curseforge.com/minecraft/mc-mods/industrial-craft/files/2353971
                 project.dependencies.reobfJarConfiguration("curse.maven:ic2-242638:2353971")
             }
+        }
+    }
+}
+
+// Ensure tests have access to minecraft classes
+sourceSets {
+    test {
+        java {
+            compileClasspath += sourceSets.patchedMc.output + sourceSets.mcLauncher.output
+            runtimeClasspath += sourceSets.patchedMc.output + sourceSets.mcLauncher.output
         }
     }
 }

--- a/src/main/java/makeo/gadomancy/common/utils/GolemEnumHelper.java
+++ b/src/main/java/makeo/gadomancy/common/utils/GolemEnumHelper.java
@@ -1,27 +1,29 @@
 package makeo.gadomancy.common.utils;
 
-import cpw.mods.fml.relauncher.Side;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import makeo.gadomancy.api.GadomancyApi;
 import makeo.gadomancy.api.golems.AdditionalGolemType;
 import makeo.gadomancy.client.events.ResourceReloadListener;
 import makeo.gadomancy.common.Gadomancy;
 import makeo.gadomancy.common.entities.golems.types.RemovedGolemType;
+
 import net.minecraftforge.common.util.EnumHelper;
+
 import thaumcraft.common.entities.golems.EnumGolemType;
+import cpw.mods.fml.relauncher.Side;
 
 /**
- * This class is part of the Gadomancy Mod
- * Gadomancy is Open Source and distributed under the
- * GNU LESSER GENERAL PUBLIC LICENSE
- * for more read the LICENSE file
+ * This class is part of the Gadomancy Mod Gadomancy is Open Source and distributed under the GNU LESSER GENERAL PUBLIC
+ * LICENSE for more read the LICENSE file
  *
  * Created by makeo @ 29.07.2015 01:07
  */
 public class GolemEnumHelper {
+
     private static final RemovedGolemType REMOVED_GOLEM_TYPE = new RemovedGolemType();
     private static final Injector INJECTOR = new Injector(EnumGolemType.class);
     private static final Injector ENUM_INJECTOR = new Injector(Enum.class);
@@ -43,18 +45,8 @@ public class GolemEnumHelper {
         return GolemEnumHelper.valuesField;
     }
 
-    private static final Class<?>[] ENUM_PARAMS = {
-        String.class,
-        int.class,
-        int.class,
-        int.class,
-        float.class,
-        boolean.class,
-        int.class,
-        int.class,
-        int.class,
-        int.class
-    };
+    private static final Class<?>[] ENUM_PARAMS = { String.class, int.class, int.class, int.class, float.class,
+            boolean.class, int.class, int.class, int.class, int.class };
 
     private static Field ordinalField;
 
@@ -62,26 +54,17 @@ public class GolemEnumHelper {
         if (GolemEnumHelper.ordinalField == null) {
             try {
                 GolemEnumHelper.ordinalField = Enum.class.getDeclaredField("ordinal");
-            } catch (NoSuchFieldException ignored) {
-            }
+            } catch (NoSuchFieldException ignored) {}
         }
         return GolemEnumHelper.ordinalField;
     }
 
     private static EnumGolemType createEnum(String name, int ordinal, AdditionalGolemType type) {
         resetEnumCache();
-        return INJECTOR.invokeUnsafeConstructor(ENUM_PARAMS, new Object[] {
-            name,
-            ordinal,
-            type.maxHealth,
-            type.armor,
-            type.movementSpeed,
-            type.fireResist,
-            type.upgradeAmount,
-            type.carryLimit,
-            type.regenDelay,
-            type.strength
-        });
+        return INJECTOR.invokeUnsafeConstructor(
+                ENUM_PARAMS,
+                new Object[] { name, ordinal, type.maxHealth, type.armor, type.movementSpeed, type.fireResist,
+                        type.upgradeAmount, type.carryLimit, type.regenDelay, type.strength });
     }
 
     private static void resetEnumCache() {
@@ -134,8 +117,7 @@ public class GolemEnumHelper {
         try {
             EnumHelper.setFailsafeFieldValue(GolemEnumHelper.getValuesField(), null, values);
             resetEnumCache();
-        } catch (Exception ignored) {
-        }
+        } catch (Exception ignored) {}
     }
 
     public static EnumGolemType addGolemType(String name, AdditionalGolemType type) {
@@ -196,8 +178,8 @@ public class GolemEnumHelper {
     }
 
     private static void resetEnum() {
-        EnumGolemType[] newValues =
-                Arrays.copyOfRange(EnumGolemType.values(), 0, GolemEnumHelper.calcDefaultGolemCount());
+        EnumGolemType[] newValues = Arrays
+                .copyOfRange(EnumGolemType.values(), 0, GolemEnumHelper.calcDefaultGolemCount());
         GolemEnumHelper.setValues(newValues);
         resetEnumCache();
     }

--- a/src/main/java/makeo/gadomancy/common/utils/Injector.java
+++ b/src/main/java/makeo/gadomancy/common/utils/Injector.java
@@ -98,18 +98,8 @@ public class Injector {
 
     public <T> T invokeUnsafeConstructor(Class<?>[] paramTypes, Object... params) {
         try {
-            final Constructor<?> constructor = this.clazz.getDeclaredConstructor(paramTypes);
-            constructor.setAccessible(true);
-            final Method acqConstructorAccessor =
-                    constructor.getClass().getDeclaredMethod("acquireConstructorAccessor");
-            acqConstructorAccessor.setAccessible(true);
-            acqConstructorAccessor.invoke(constructor);
-            Field constructorAccessorField = constructor.getClass().getDeclaredField("constructorAccessor");
-            constructorAccessorField.setAccessible(true);
-            Object constructorAccessor = constructorAccessorField.get(constructor);
-            Method newInstance = constructorAccessor.getClass().getMethod("newInstance", Object[].class);
-            newInstance.setAccessible(true);
-            Object created = newInstance.invoke(constructorAccessor, new Object[] {params});
+            final Method constructor = this.clazz.getMethod("gadomancyRawCreate", paramTypes);
+            Object created = constructor.invoke(null, params);
             return (T) created;
         } catch (Throwable e) {
             Throwables.propagate(e);

--- a/src/main/java/makeo/gadomancy/common/utils/Injector.java
+++ b/src/main/java/makeo/gadomancy/common/utils/Injector.java
@@ -1,23 +1,24 @@
 package makeo.gadomancy.common.utils;
 
-import com.google.common.base.Throwables;
-import cpw.mods.fml.relauncher.ReflectionHelper;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+
 import sun.misc.Unsafe;
 
+import com.google.common.base.Throwables;
+import cpw.mods.fml.relauncher.ReflectionHelper;
+
 /**
- * This class is part of the Gadomancy Mod
- * Gadomancy is Open Source and distributed under the
- * GNU LESSER GENERAL PUBLIC LICENSE
- * for more read the LICENSE file
+ * This class is part of the Gadomancy Mod Gadomancy is Open Source and distributed under the GNU LESSER GENERAL PUBLIC
+ * LICENSE for more read the LICENSE file
  *
  * Created by makeo @ 02.12.13 18:45
  */
 public class Injector {
+
     static final Unsafe UNSAFE;
 
     static {
@@ -81,7 +82,7 @@ public class Injector {
     }
 
     public <T> T invokeConstructor(Class<?> clazz, Object param) {
-        return this.invokeConstructor(new Class[] {clazz}, param);
+        return this.invokeConstructor(new Class[] { clazz }, param);
     }
 
     public <T> T invokeConstructor(Class<?>[] classes, Object... params) {
@@ -112,7 +113,7 @@ public class Injector {
     }
 
     public <T> T invokeMethod(String name, Class clazz, Object param) {
-        return this.invokeMethod(name, new Class[] {clazz}, param);
+        return this.invokeMethod(name, new Class[] { clazz }, param);
     }
 
     public <T> T invokeMethod(String name, Class[] classes, Object... params) {
@@ -161,8 +162,7 @@ public class Injector {
                 if (object == null) {
                     base = UNSAFE.staticFieldBase(field);
                 }
-                final long offset = Modifier.isStatic(field.getModifiers())
-                        ? UNSAFE.staticFieldOffset(field)
+                final long offset = Modifier.isStatic(field.getModifiers()) ? UNSAFE.staticFieldOffset(field)
                         : UNSAFE.objectFieldOffset(field);
                 UNSAFE.putObject(base, offset, value);
                 return true;
@@ -187,8 +187,7 @@ public class Injector {
                 if (object == null) {
                     base = UNSAFE.staticFieldBase(field);
                 }
-                final long offset = Modifier.isStatic(field.getModifiers())
-                        ? UNSAFE.staticFieldOffset(field)
+                final long offset = Modifier.isStatic(field.getModifiers()) ? UNSAFE.staticFieldOffset(field)
                         : UNSAFE.objectFieldOffset(field);
                 UNSAFE.putInt(base, offset, value);
                 return true;
@@ -233,8 +232,7 @@ public class Injector {
 
     public static Method findMethod(Class clazz, Class returnType, Class[] paramTypes) {
         for (Method m : clazz.getDeclaredMethods()) {
-            if (Arrays.equals(m.getParameterTypes(), paramTypes)
-                    && m.getReturnType().equals(returnType)) {
+            if (Arrays.equals(m.getParameterTypes(), paramTypes) && m.getReturnType().equals(returnType)) {
                 return m;
             }
         }

--- a/src/main/java/makeo/gadomancy/coremod/GadomancyTransformer.java
+++ b/src/main/java/makeo/gadomancy/coremod/GadomancyTransformer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
@@ -24,6 +25,7 @@ public class GadomancyTransformer extends AccessTransformer {
     public static final String NAME_RENDER_EVENT_HANDLER = "thaumcraft.client.lib.RenderEventHandler";
     public static final String NAME_NEI_ITEMPANEL = "codechicken.nei.ItemPanel";
     public static final String NAME_ENTITY_LIVING_BASE = "net.minecraft.entity.EntityLivingBase";
+    public static final String NAME_GOLEM_ENUM = "thaumcraft.common.entities.golems.EnumGolemType";
 
     public GadomancyTransformer() throws IOException {}
 
@@ -34,7 +36,8 @@ public class GadomancyTransformer extends AccessTransformer {
                 || transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_NODE_RENDERER)
                 || transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_RENDER_EVENT_HANDLER)
                 || transformedName.equals(GadomancyTransformer.NAME_NEI_ITEMPANEL)
-                || transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_ENTITY_LIVING_BASE);
+                || transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_ENTITY_LIVING_BASE)
+                || transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_GOLEM_ENUM);
         if (!needsTransform) return super.transform(name, transformedName, bytes);
 
         FMLLog.info("[GadomancyTransformer] Transforming " + name + ": " + transformedName);
@@ -178,6 +181,36 @@ public class GadomancyTransformer extends AccessTransformer {
                     mn.instructions = newInstructions;
                 }
             }
+        } else if (transformedName.equalsIgnoreCase(GadomancyTransformer.NAME_GOLEM_ENUM)) {
+            // Create constructor accessor
+            final MethodVisitor methodVisitor = node.visitMethod(
+                    Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                    "gadomancyRawCreate",
+                    "(Ljava/lang/String;IIIFZIIII)Lthaumcraft/common/entities/golems/EnumGolemType;",
+                    null,
+                    null);
+            methodVisitor.visitCode();
+            methodVisitor.visitTypeInsn(Opcodes.NEW, "thaumcraft/common/entities/golems/EnumGolemType");
+            methodVisitor.visitInsn(Opcodes.DUP);
+            methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 1);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 2);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 3);
+            methodVisitor.visitVarInsn(Opcodes.FLOAD, 4);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 5);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 6);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 7);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 8);
+            methodVisitor.visitVarInsn(Opcodes.ILOAD, 9);
+            methodVisitor.visitMethodInsn(
+                    Opcodes.INVOKESPECIAL,
+                    "thaumcraft/common/entities/golems/EnumGolemType",
+                    "<init>",
+                    "(Ljava/lang/String;IIIFZIIII)V",
+                    false);
+            methodVisitor.visitInsn(Opcodes.ARETURN);
+            methodVisitor.visitMaxs(12, 10);
+            methodVisitor.visitEnd();
         }
 
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);


### PR DESCRIPTION
In order to make EnumHelper java 9+ compatible lwjgl3ify has to change its internals significantly, and doesn't preserve all the private methods as they don't all make sense to exist. This seems to be the only mod depending on them, so I include a j9+ compatible implementation of what it needs here. Also added clearing the enum cache after modifying it because it wasn't doing it before, which could lead to unpredictable runtime behavior.