### PR TITLE
Fix Automagy Overcounting Aspect

### DIFF
--- a/src/main/java/makeo/gadomancy/common/blocks/tiles/TileEssentiaCompressor.java
+++ b/src/main/java/makeo/gadomancy/common/blocks/tiles/TileEssentiaCompressor.java
@@ -128,7 +128,14 @@ public class TileEssentiaCompressor extends SynchronizedTileEntity implements IE
     @Override
     @Optional.Method(modid = "Automagy")
     public AspectList getAspectsBase() {
-        return this.getAspects();
+        if (this.isMultiblockFormed() && this.isAccessPoint()) {
+            TileEssentiaCompressor master = this.tryFindMasterTile();
+            if (master != null) {
+                return master.getAspects();
+            }
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Fix Automagy's Crystal Eye overcounting aspect in the multiblock structure.

Issue as explained by @SwedishKaito:
![image](https://github.com/GTNewHorizons/Gadomancy/assets/47131096/314c0aba-6551-4cc9-9ac5-b9d21bfeb85a)
