### PR TITLE
Fix unsafe usage of FakePlayer in Infusion Claw

### DIFF
--- a/src/main/java/makeo/gadomancy/common/blocks/tiles/TileInfusionClaw.java
+++ b/src/main/java/makeo/gadomancy/common/blocks/tiles/TileInfusionClaw.java
@@ -10,21 +10,17 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.ItemInWorldManager;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
-import net.minecraft.network.NetworkManager;
-import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.EnumConnectionState;
-import net.minecraft.network.NetHandlerPlayServer;
-import net.minecraft.network.Packet;
-import net.minecraft.network.play.client.*;
-    
+
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -282,7 +278,11 @@ public class TileInfusionClaw extends SynchronizedTileEntity implements ISidedIn
             }
 
             AdvancedFakePlayer fakePlayer = new AdvancedFakePlayer((WorldServer) world, TileInfusionClaw.FAKE_UUID);
-            fakePlayer.playerNetServerHandler = new NetHandlerPlayServer(MinecraftServer.getServer(), new NetworkManager(false), fakePlayer){
+            fakePlayer.playerNetServerHandler = new NetHandlerPlayServer(
+                    MinecraftServer.getServer(),
+                    new NetworkManager(false),
+                    fakePlayer) {
+
                 @Override
                 public void sendPacket(Packet discard) {}
             };
@@ -478,5 +478,4 @@ public class TileInfusionClaw extends SynchronizedTileEntity implements ISidedIn
         return (!this.isLocked() || !this.hasSufficientVis()) && this.canInsertItem(slot, stack, side);
     }
 
-   
 }

--- a/src/main/java/makeo/gadomancy/common/blocks/tiles/TileInfusionClaw.java
+++ b/src/main/java/makeo/gadomancy/common/blocks/tiles/TileInfusionClaw.java
@@ -16,8 +16,15 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.util.ForgeDirection;
-
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.EnumConnectionState;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.client.*;
+    
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -275,6 +282,10 @@ public class TileInfusionClaw extends SynchronizedTileEntity implements ISidedIn
             }
 
             AdvancedFakePlayer fakePlayer = new AdvancedFakePlayer((WorldServer) world, TileInfusionClaw.FAKE_UUID);
+            fakePlayer.playerNetServerHandler = new NetHandlerPlayServer(MinecraftServer.getServer(), new NetworkManager(false), fakePlayer){
+                @Override
+                public void sendPacket(Packet discard) {}
+            };
             this.loadResearch(fakePlayer);
 
             if (behavior.hasVisCost()) {
@@ -287,6 +298,7 @@ public class TileInfusionClaw extends SynchronizedTileEntity implements ISidedIn
 
             if (this.im == null) {
                 this.im = new ItemInWorldManager(world);
+                this.im.thisPlayerMP = fakePlayer;
             } else {
                 this.im.setWorld((WorldServer) world);
             }
@@ -465,4 +477,6 @@ public class TileInfusionClaw extends SynchronizedTileEntity implements ISidedIn
     public boolean canExtractItem(int slot, ItemStack stack, int side) {
         return (!this.isLocked() || !this.hasSufficientVis()) && this.canInsertItem(slot, stack, side);
     }
+
+   
 }


### PR DESCRIPTION
Bug:
1.Place a Infusion Mat&Infusion Claw
2.Claim chunk that contains those blocks via ServerUtils
3.Deny Fake Player in SU settings
4.Use Infusion Claw and game crashes
[crash-2024-11-25_15.06.07-server.txt](https://github.com/user-attachments/files/17898821/crash-2024-11-25_15.06.07-server.txt)
![2024-11-25_15 14 23](https://github.com/user-attachments/assets/d35d5482-d6ab-49cd-a876-23f0fd56f86e)

ItemInWorldManager.java will use 'thisPlayerMP.playerNetServerHandler' if InteractEvent is cancelled.
Infusion Claw did not set thisPlayerMP, so game crashes when Fake Player is blocked.
This PR assign Fake Player to 'thisPlayerMP', and add a dummy NetHandlerPlayServer instance.
To prevent game crash.(tested in single player mode)

Video before PR:Crashing the game.
https://github.com/user-attachments/assets/1a544a47-2e94-452b-b1e6-2cb23603f201
Video after PR:Not crashing the game.
https://github.com/user-attachments/assets/0f572c10-27bd-45e2-ae41-54f2f6cf88aa


