### PR TITLE
Fix mirrored jar labels not saving

### DIFF
--- a/src/main/java/makeo/gadomancy/common/items/ItemBlockRemoteJar.java
+++ b/src/main/java/makeo/gadomancy/common/items/ItemBlockRemoteJar.java
@@ -23,6 +23,7 @@ import makeo.gadomancy.common.blocks.tiles.TileRemoteJar;
 import makeo.gadomancy.common.registration.RegisteredBlocks;
 import makeo.gadomancy.common.utils.NBTHelper;
 import makeo.gadomancy.common.utils.StringHelper;
+import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.blocks.ItemJarFilled;
 import thaumcraft.common.config.ConfigItems;
@@ -129,6 +130,7 @@ public class ItemBlockRemoteJar extends ItemBlock {
 
             if (!world.isRemote) {
                 tile.networkId = NBTHelper.getUUID(stack.getTagCompound(), "networkId");
+                tile.aspectFilter = Aspect.getAspect(stack.getTagCompound().getString("AspectFilter"));
                 tile.markForUpdate();
             }
         }


### PR DESCRIPTION
Fixes old (closed but unfixed) issue https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/4942.

Was taken from #29 as I missed that this PR had a 3rd thing in it