### PR TITLE
Fix crash with dragonapi

### DIFF
--- a/src/main/java/makeo/gadomancy/common/events/EventHandlerRedirect.java
+++ b/src/main/java/makeo/gadomancy/common/events/EventHandlerRedirect.java
@@ -5,6 +5,7 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -46,6 +47,18 @@ public class EventHandlerRedirect {
         if (MiscUtils.isANotApprovedOrMisunderstoodPersonFromMoreDoor(player)) return true;
         return stack != null
                 && EnchantmentHelper.getEnchantmentLevel(RegisteredEnchantments.revealer.effectId, stack) > 0;
+    }
+
+    // this overload is called by DragonAPI
+    @SideOnly(Side.CLIENT)
+    public static void preNodeRender(TileEntity tile) {
+        EventHandlerRedirect.preNodeRender();
+    }
+
+    // this overload is called by DragonAPI
+    @SideOnly(Side.CLIENT)
+    public static void postNodeRender(TileEntity tile) {
+        EventHandlerRedirect.postNodeRender();
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
https://github.com/GTNewHorizons/Gadomancy/pull/41#issuecomment-3544768937


```
java.lang.NoSuchMethodError: 'void makeo.gadomancy.common.events.EventHandlerRedirect.preNodeRender(net.minecraft.tileentity.TileEntity)'
	at Launch//makeo.gadomancy.client.renderers.tile.RenderTileNodeBasic.renderTileEntityAt(RenderTileNodeBasic.java:538)
	at Launch//makeo.gadomancy.client.renderers.tile.RenderTileExtendedNode.func_147500_a(RenderTileExtendedNode.java:28)
	at Launch//Reika.DragonAPI.Instantiable.Event.Client.TileEntityRenderEvent.fire(TileEntityRenderEvent.java:42)
	at Launch//net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher.func_147549_a(SourceFile:100)
	at Launch//net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher.func_147544_a(SourceFile:92)
	at Launch//net.minecraft.client.renderer.RenderGlobal.mixinextras$bridge$func_147544_a$117(RenderGlobal.java)
	at Launch//net.minecraft.client.renderer.RenderGlobal.wrapOperation$zbb000$beddium$safeRenderTileEntity(RenderGlobal.java:2755)
	at Launch//net.minecraft.client.renderer.RenderGlobal.func_147589_a(RenderGlobal.java:483)
	at Launch//net.minecraft.client.renderer.EntityRenderer.func_78471_a(EntityRenderer.java:1224)
	at Launch//Reika.DragonAPI.ASM.ASMCallsClient.onRenderWorld(ASMCallsClient.java:86)
	at Launch//net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1015)
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001)
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:12506)
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
```