### PR TITLE
[Memory-opti:runtime allocations] Reduce NBT Tag spam

### DIFF
--- a/src/main/java/makeo/gadomancy/common/crafting/EtherealFamiliarUpgradeRecipe.java
+++ b/src/main/java/makeo/gadomancy/common/crafting/EtherealFamiliarUpgradeRecipe.java
@@ -17,20 +17,22 @@ import thaumcraft.api.crafting.InfusionRecipe;
  */
 public class EtherealFamiliarUpgradeRecipe extends InfusionRecipe {
 
-    private FamiliarAugment toAdd;
-    private int requiredPreviousLevel;
+    private final FamiliarAugment toAdd;
+    private final int requiredPreviousLevel;
+    private final Object cachedOutput;
 
     public EtherealFamiliarUpgradeRecipe(String research, int inst, AspectList aspects2, ItemStack familiarIn,
             FamiliarAugment toAdd, int reqPrev, ItemStack... surroundings) {
         super(research, null, inst, aspects2, familiarIn, surroundings);
         this.toAdd = toAdd;
         this.requiredPreviousLevel = reqPrev;
+        this.cachedOutput = super.getRecipeOutput();
     }
 
     @Override
     public boolean matches(ArrayList<ItemStack> input, ItemStack in, World world, EntityPlayer player) {
         if (in == null || !(in.getItem() instanceof ItemEtherealFamiliar)) return false; // We call it "FamiliarAugment"
-                                                                                         // Recipe for a reason..
+        // Recipe for a reason..
         if (this.getRecipeInput() == null || !(this.getRecipeInput().getItem() instanceof ItemEtherealFamiliar))
             return false; // A bit late but still working..
 
@@ -56,7 +58,7 @@ public class EtherealFamiliarUpgradeRecipe extends InfusionRecipe {
         // Normal infusionrecipe stuff...
 
         ItemStack inCopy;
-        ArrayList<ItemStack> ii = new ArrayList<ItemStack>();
+        ArrayList<ItemStack> ii = new ArrayList<>();
         for (ItemStack is : input) {
             ii.add(is.copy());
         }
@@ -81,9 +83,14 @@ public class EtherealFamiliarUpgradeRecipe extends InfusionRecipe {
     }
 
     @Override
-    public Object getRecipeOutput(ItemStack in) {
-        ItemStack inputCopy = in.copy();
+    public Object getRecipeOutput(ItemStack input) {
+        ItemStack inputCopy = input.copy();
         ItemEtherealFamiliar.incrementAugmentLevel(inputCopy, this.toAdd);
         return inputCopy;
+    }
+
+    @Override
+    public Object getRecipeOutput() {
+        return this.cachedOutput;
     }
 }

--- a/src/main/java/makeo/gadomancy/common/crafting/InfusionDisguiseArmor.java
+++ b/src/main/java/makeo/gadomancy/common/crafting/InfusionDisguiseArmor.java
@@ -36,8 +36,13 @@ public class InfusionDisguiseArmor extends InfusionRunicAugmentRecipe {
             new ItemStack(ConfigItems.itemResource, 1, 3) };
     public static final AspectList ASPECTS = new AspectList().add(Aspect.SLIME, 12).add(Aspect.ARMOR, 10)
             .add(Aspect.MAGIC, 8);
+    private final Map<ItemStack, List<ItemStack>> cachedItems = new HashMap<>();
+    private final Object cachedOutput;
 
-    private Map<ItemStack, List<ItemStack>> cachedItems = new HashMap<ItemStack, List<ItemStack>>();
+    public InfusionDisguiseArmor() {
+        super();
+        this.cachedOutput = super.getRecipeOutput();
+    }
 
     @Override
     public boolean matches(ArrayList<ItemStack> input, ItemStack central, World world, EntityPlayer player) {
@@ -47,7 +52,7 @@ public class InfusionDisguiseArmor extends InfusionRunicAugmentRecipe {
         }
 
         List<ItemStack> copy = (List<ItemStack>) input.clone();
-        List<ItemStack> result = new ArrayList<ItemStack>(copy.size());
+        List<ItemStack> result = new ArrayList<>(copy.size());
         for (ItemStack required : InfusionDisguiseArmor.COMPONENTS) {
             boolean contains = false;
             for (int i = 0; i < copy.size(); i++) {
@@ -77,7 +82,7 @@ public class InfusionDisguiseArmor extends InfusionRunicAugmentRecipe {
     public ItemStack[] getComponents(ItemStack input) {
         List<ItemStack> components = this.cachedItems.get(input);
         if (components != null) {
-            return components.toArray(new ItemStack[components.size()]);
+            return components.toArray(new ItemStack[0]);
         }
         return new ItemStack[0];
     }
@@ -100,6 +105,11 @@ public class InfusionDisguiseArmor extends InfusionRunicAugmentRecipe {
             return InfusionDisguiseArmor.disguiseStack(input, components.get(0));
         }
         return input;
+    }
+
+    @Override
+    public Object getRecipeOutput() {
+        return this.cachedOutput;
     }
 
     public static ItemStack disguiseStack(ItemStack stack, ItemStack disguise) {

--- a/src/main/java/makeo/gadomancy/common/crafting/InfusionUpgradeRecipe.java
+++ b/src/main/java/makeo/gadomancy/common/crafting/InfusionUpgradeRecipe.java
@@ -25,14 +25,14 @@ import thaumcraft.common.entities.golems.EnumGolemType;
 public class InfusionUpgradeRecipe extends InfusionRecipe {
 
     private static final ItemStack DEFAULT_OUTPUT = new ItemStack(Blocks.dirt);
+    private final GolemUpgrade<?> upgrade;
+    private final Object cachedOutput;
 
-    private final GolemUpgrade upgrade;
-
-    private InfusionUpgradeRecipe(String research, GolemUpgrade upgrade, int inst, AspectList aspects2, ItemStack input,
-            ItemStack[] recipe) {
+    private InfusionUpgradeRecipe(String research, GolemUpgrade<?> upgrade, int inst, AspectList aspects2,
+            ItemStack input, ItemStack[] recipe) {
         super(research, InfusionUpgradeRecipe.DEFAULT_OUTPUT, inst, aspects2, input, recipe);
-
         this.upgrade = upgrade;
+        this.cachedOutput = super.getRecipeOutput();
     }
 
     @Override
@@ -45,6 +45,11 @@ public class InfusionUpgradeRecipe extends InfusionRecipe {
         ItemStack output = input.copy();
         this.upgrade.addUpgrade(output);
         return output;
+    }
+
+    @Override
+    public Object getRecipeOutput() {
+        return this.cachedOutput;
     }
 
     public static InfusionUpgradeRecipe[] createRecipes(String research, GolemUpgrade upgrade, int inst,

--- a/src/main/java/makeo/gadomancy/common/crafting/InfusionVisualDisguiseArmor.java
+++ b/src/main/java/makeo/gadomancy/common/crafting/InfusionVisualDisguiseArmor.java
@@ -60,23 +60,19 @@ public class InfusionVisualDisguiseArmor extends InfusionRecipe {
     }
 
     private void findArmorItems() {
-        List<ItemStack> items = new ArrayList<ItemStack>();
+        List<ItemStack> items = new ArrayList<>();
         for (Object o : Item.itemRegistry) {
-            if (o instanceof Item && ((Item) o).getCreativeTab() != null) {
-                List list = new ArrayList();
-
-                try {
-                    ((Item) o).getSubItems((Item) o, ((Item) o).getCreativeTab(), list);
-                } catch (Throwable ignored) {}
-
-                for (Object o2 : list) {
-                    if (o2 != null && o2 instanceof ItemStack && EntityLiving.getArmorPosition((ItemStack) o2) != 0) {
-                        items.add((ItemStack) o2);
-                    }
+            if (o instanceof Item item && item.getCreativeTab() != null) {
+                final ItemStack stack = new ItemStack(item);
+                if (EntityLiving.getArmorPosition(stack) != 0) {
+                    try {
+                        item.getSubItems(item, item.getCreativeTab(), items);
+                    } catch (Throwable ignored) {}
                 }
             }
         }
-        InfusionVisualDisguiseArmor.armorItems = items.toArray(new ItemStack[items.size()]);
+        items.removeIf(stack -> stack == null || EntityLiving.getArmorPosition(stack) == 0);
+        InfusionVisualDisguiseArmor.armorItems = items.toArray(new ItemStack[0]);
     }
 
     private boolean canSee(ItemStack stack) {


### PR DESCRIPTION
The method `public Object getRecipeOutput()` is called mullions of times during startup by the recipe removing algorithm so I'm caching the result to avoid the new item stacks creations from the original method `public Object getRecipeOutput(ItemStack input)`