### PR TITLE
Fix crash when golem is placed on dedicated server

### DIFF
--- a/src/main/java/makeo/gadomancy/common/CommonProxy.java
+++ b/src/main/java/makeo/gadomancy/common/CommonProxy.java
@@ -65,6 +65,8 @@ public class CommonProxy implements IGuiHandler {
     }
 
     public void initalize() {
+        EVENT_HANDLER_GOLEM = new EventHandlerGolem();
+        MinecraftForge.EVENT_BUS.register(EVENT_HANDLER_GOLEM);
         NetworkRegistry.INSTANCE.registerGuiHandler(Gadomancy.instance, this);
         RegisteredEnchantments.init();
         RegisteredRecipes.init();
@@ -132,8 +134,6 @@ public class CommonProxy implements IGuiHandler {
     public EventHandlerEntity EVENT_HANDLER_ENTITY;
 
     public void onServerAboutToStart(FMLServerAboutToStartEvent event) {
-        EVENT_HANDLER_GOLEM = new EventHandlerGolem();
-        MinecraftForge.EVENT_BUS.register(EVENT_HANDLER_GOLEM);
         EVENT_HANDLER_NETWORK = new EventHandlerNetwork();
         FMLCommonHandler.instance().bus().register(EVENT_HANDLER_NETWORK);
         EVENT_HANDLER_WORLD = new EventHandlerWorld();
@@ -144,8 +144,6 @@ public class CommonProxy implements IGuiHandler {
     }
 
     public void onServerStopped(FMLServerStoppedEvent event) {
-        MinecraftForge.EVENT_BUS.unregister(EVENT_HANDLER_GOLEM);
-        EVENT_HANDLER_GOLEM = null;
         FMLCommonHandler.instance().bus().unregister(EVENT_HANDLER_NETWORK);
         EVENT_HANDLER_NETWORK = null;
         MinecraftForge.EVENT_BUS.unregister(EVENT_HANDLER_WORLD);


### PR DESCRIPTION
With the changes in #44 registration of several EventHandler classes was moved to the ServerStartEvent.

At least EventHandlerGolem is needed to be registered on both logical sides, when the server is running "remote".
Otherwise when placing a new golem, golem-data is not persisted to the world and then the rendering fails.

Crash in the mentioned issue only happens when playing on a dedicated server.

I'm quite out of touch with Forge for 1.7.10 and where which events are fired, so the following is just a "feeling", but I'm not quite sure that it's correct for the other affected Handlers only being registered on Server as there are several world.isRemote() checks in the contained EventHandlers.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#23000